### PR TITLE
Add support for w83795adg-i2c-1-2f sensors (HP N54L)

### DIFF
--- a/usr/share/openmediavault/mkconf/sensors
+++ b/usr/share/openmediavault/mkconf/sensors
@@ -259,6 +259,7 @@ if [ ! -z $mb_temp ]; then
         "sensors-it8728"*) rrd=1 ;;
         "sensors-thinkpad-isa"*) rrd=11 ;;
         "sensors-fschds-"*) rrd=3 ;;
+        "sensors-w83795adg-i2c-1-2f"*) rrd=5 ;;
         *) rrd=2 ;;
     esac
 
@@ -291,6 +292,7 @@ if [ ! -z $mb_temp ]; then
         "sensors-it8728"*) rrd=1 ;;
         "sensors-thinkpad-isa"*) rrd=11 ;;
         "sensors-fschds-"*) rrd=3 ;;
+        "sensors-w83795adg-i2c-1-2f"*) rrd=5 ;;
         *) rrd=2 ;;
     esac
     cat <<EOF >> $MBoutfile
@@ -368,6 +370,7 @@ if [ ! -z $sys_fan ]; then
         "sensors-it8728"*) rrd=3 ;;
         "sensors-fschds-"*) rrd=3 ;;
         "sensors-f71869a"*) rrd=1 ;;
+        "sensors-w83795adg-i2c-1-2f"*) rrd=1 ;;
         *) rrd=2 ;;
     esac
     if [ ! -z "$(omv_config_get "${XPATH}/sysoffset")" ]; then
@@ -543,6 +546,8 @@ if [ "$(omv_config_get "${XPATH}/mbtemp")" = "1" ]; then
         mb_temp="sensors-w83795adg-i2c-4-2f"
     elif [ -e /var/lib/rrdcached/db/localhost/sensors-w83795adg-i2c-0-2f/temperature-temp2.rrd ]; then
         mb_temp="sensors-w83795adg-i2c-0-2f"
+    elif [ -e /var/lib/rrdcached/db/localhost/sensors-w83795adg-i2c-1-2f/temperature-temp5.rrd ]; then
+        mb_temp="sensors-w83795adg-i2c-1-2f"
     elif [ -e /var/lib/rrdcached/db/localhost/sensors-it877*/temperature-temp1.rrd ]; then
         mb_temp="sensors-it877*"
     elif [ -e /var/lib/rrdcached/db/localhost/sensors-emc6d103-i2c-1-2e/temperature-temp2.rrd ]; then
@@ -645,6 +650,8 @@ if [ "$(omv_config_get "${XPATH}/sysfanenable")" = "1" ]; then
         sys_fan="sensors-k10temp*"
     elif [ -e /var/lib/rrdcached/db/localhost/sensors-w83795adg-i2c-4-2f/fanspeed-fan2.rrd ]; then
         sys_fan="sensors-w83795adg-i2c-4-2f"
+    elif [ -e /var/lib/rrdcached/db/localhost/sensors-w83795adg-i2c-1-2f/fanspeed-fan1.rrd ]; then
+        sys_fan="sensors-w83795adg-i2c-1-2f"
     elif [ -e /var/lib/rrdcached/db/localhost/sensors-w83667hg*/fanspeed-fan1.rrd ]; then
         sys_fan="sensors-w83667hg*"
     elif [ -e /var/lib/rrdcached/db/localhost/sensors-emc6d103-i2c-1-2d/fanspeed-fan1.rrd ]; then


### PR DESCRIPTION
Add support for w83795adg-i2c-1-2f sensors for MB temp and SYSFAN monitoring on HP N54L Microserver.

Need to use un-official driver from [https://github.com/fetzerch/hp-n54l-drivers](https://github.com/fetzerch/hp-n54l-drivers)